### PR TITLE
fix: Fix compression after combination check.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ exports.compress = function (geohashes, minlevel, maxlevel,approxHashesCount) {
 
 
                         if (geohashLength >= maxlevel) {
-                            finalGeohashes.add(present.slice(0, -maxlevel));
+                            finalGeohashes.add(present.slice(0, maxlevel));
                         }
                         else {
                             finalGeohashes.add(present);


### PR DESCRIPTION
This actually wants to be `maxlevel`, not `-maxlevel` per https://github.com/ashwin711/georaptor/blob/9bd3a0950478bdd4ea1a977184d93d1affe1686e/georaptor.py#L70.

I mean, I should probably write some tests here, but w/e.